### PR TITLE
Support Python 3.6

### DIFF
--- a/examples/rental_comps.py
+++ b/examples/rental_comps.py
@@ -1,13 +1,13 @@
-from __future__ import annotations
-
 # 1st Party Libraries
+from typing import List
+
 import open_exchange
-from open_exchange.types import AddressFields, RentalCompsFilters, RentalCompsResult
+from open_exchange.types import AddressFields, RentalCompsFilters
 
 # get API KEY from environment variable OPEN_EXCHANGE_API_KEY
 client = open_exchange.OpenExchangeClient()
 
-addresses: list[AddressFields] = [
+addresses: List[AddressFields] = [
     {
         'street': '1850 NW 37th St',
         'city': 'Oakland Park',
@@ -24,7 +24,7 @@ filters: RentalCompsFilters = {
 }
 
 # get rental comps for a iterable of addresses with filters
-for result in client.data.rental_comps.fetch(addresses=addresses, filters=filters):  # type: RentalCompsResult
+for result in client.data.rental_comps.fetch(addresses=addresses, filters=filters):
     assert result['token'] == 'client-provided-token-1'
 
     print('Subject property details:', result['subject_property_details'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ import_heading_firstparty = "1st Party Libraries"
 import_heading_localfolder = "Local Folder"
 
 # Consistenly use PEP 563-style annotations, avoids common confusion and issues.
-add_imports = ["from __future__ import annotations"]
+# add_imports = ["from __future__ import annotations"]  # TODO: Enable this once we're on Python 3.7+
 force_adds = true

--- a/src/open_exchange/__init__.py
+++ b/src/open_exchange/__init__.py
@@ -1,7 +1,5 @@
 """Open Exchange Python SDK."""
 
-from __future__ import annotations
-
 __version__ = '0.1.2'
 
 # 1st Party Libraries

--- a/src/open_exchange/client.py
+++ b/src/open_exchange/client.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 # Standard Library
 import logging
 import os
 from http import HTTPStatus
+from typing import Optional
 
 # Third-Party Libraries
 import requests
@@ -25,8 +24,8 @@ class OpenExchangeClient:
     def __init__(
         self,
         *,
-        api_key: str | None = None,
-        base_url: str | None = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
     ) -> None:
         if api_key is None:
             api_key = os.getenv('OPEN_EXCHANGE_API_KEY')
@@ -43,7 +42,7 @@ class OpenExchangeClient:
 
         self.data = resources.Data(self)
 
-    def _request(self, method: str, path: str, body: dict | None = None) -> dict:
+    def _request(self, method: str, path: str, body: Optional[dict] = None) -> dict:
         session = requests.Session()
         session.mount('https://', requests.adapters.HTTPAdapter(max_retries=self._retry_config))
 

--- a/src/open_exchange/compat.py
+++ b/src/open_exchange/compat.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 try:
     # Standard Library
     from functools import cached_property

--- a/src/open_exchange/contants.py
+++ b/src/open_exchange/contants.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_RETRY_BACKOFF_FACTOR = 0.1
 

--- a/src/open_exchange/exceptions.py
+++ b/src/open_exchange/exceptions.py
@@ -1,5 +1,2 @@
-from __future__ import annotations
-
-
 class OpenExchangeError(Exception):
     pass

--- a/src/open_exchange/resource.py
+++ b/src/open_exchange/resource.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 # Standard Library
 from typing import TYPE_CHECKING
 
@@ -9,8 +7,8 @@ if TYPE_CHECKING:
 
 
 class APIResource:
-    client: OpenExchangeClient
+    client: 'OpenExchangeClient'
 
-    def __init__(self, client: OpenExchangeClient) -> None:
+    def __init__(self, client: 'OpenExchangeClient') -> None:
         self.client = client
         self.request = client._request

--- a/src/open_exchange/resources/__init__.py
+++ b/src/open_exchange/resources/__init__.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 # 1st Party Libraries
 from open_exchange.resources.data.data import Data
 
 __all__ = [
-    "Data",
+    'Data',
 ]

--- a/src/open_exchange/resources/data/__init__.py
+++ b/src/open_exchange/resources/data/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/src/open_exchange/resources/data/data.py
+++ b/src/open_exchange/resources/data/data.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 # 1st Party Libraries
 from open_exchange.compat import cached_property
 from open_exchange.resource import APIResource

--- a/src/open_exchange/resources/data/rental_comps.py
+++ b/src/open_exchange/resources/data/rental_comps.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 # Standard Library
 import concurrent.futures
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Optional
 
 # Third-Party Libraries
 import more_itertools
@@ -19,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class RentalComps(APIResource):
-    def __init__(self, client: OpenExchangeClient) -> None:
+    def __init__(self, client: 'OpenExchangeClient') -> None:
         super().__init__(client)
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENT_REQUESTS)
 
@@ -27,8 +25,8 @@ class RentalComps(APIResource):
         self,
         addresses: Iterable[AddressFields],
         *,
-        filters: RentalCompsFilters | None = None,
-        num_comps: int | None = 10,
+        filters: Optional[RentalCompsFilters] = None,
+        num_comps: Optional[int] = 10,
         max_addresses_per_request: int = MAX_ADDRESSES_PER_RENTAL_COMPS_REQUEST,
     ) -> Iterable[RentalCompsResult]:
         """

--- a/src/open_exchange/types.py
+++ b/src/open_exchange/types.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 # Standard Library
 import enum
 from datetime import date
-from typing import Optional, Sequence, TypedDict, Union
+from typing import Optional, Sequence, Union
+
+from open_exchange.typing import TypedDict
 
 
 class AddressFields(TypedDict, total=False):
@@ -329,7 +329,7 @@ class ListingStatus(str, enum.Enum):
 
 
 class RentalCompsFilters(TypedDict, total=False):
-    bedrooms_total: NumericFilterType | None
+    bedrooms_total: Optional[NumericFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a number
     of bedrooms that are within the provided `value` of the supplied address.
@@ -342,7 +342,7 @@ class RentalCompsFilters(TypedDict, total=False):
     (inclusive).
     """
 
-    bathrooms_full: NumericFilterType | None
+    bathrooms_full: Optional[NumericFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a number
     of full bathrooms that are within the provided `value` of the supplied
@@ -355,7 +355,7 @@ class RentalCompsFilters(TypedDict, total=False):
     value (inclusive).
     """
 
-    bathrooms_half: NumericFilterType | None
+    bathrooms_half: Optional[NumericFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a number
     of half bathrooms that are within the provided `value` of the supplied
@@ -368,21 +368,21 @@ class RentalCompsFilters(TypedDict, total=False):
     value (inclusive).
     """
 
-    distance: float | None
+    distance: Optional[float]
     """
     The maximum distance of the rental comp from the requested address. If no 
     distance filter was provided, a default value of 2 will be used. This
     distance value provided must be greater than 0 and less than or equal to 25.
     """
 
-    min_similarity_score: float | None
+    min_similarity_score: Optional[float]
     """
     Lower bound for the similarity score filter for nearby properties to be 
     considered as comps. Float within the range from 0 (Least similar) to 1
     (Most similar).
     """
 
-    living_area_sqft: NumericFilterType | None
+    living_area_sqft: Optional[NumericFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a square
     footage that is within the provided percentage `value` of the supplied
@@ -396,7 +396,7 @@ class RentalCompsFilters(TypedDict, total=False):
     (inclusive).
     """
 
-    date: DateFilterType | None
+    date: Optional[DateFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a
     `year_built` within provided `value` years of the supplied address. For
@@ -409,7 +409,7 @@ class RentalCompsFilters(TypedDict, total=False):
     returned.
     """
 
-    year_built: NumericFilterType | None
+    year_built: Optional[NumericFilterType]
     """
     When the **`FilterRelativeNumeric`** is used, only comps which have a
     `year_built` within provided `value` years of the supplied address. For

--- a/src/open_exchange/typing.py
+++ b/src/open_exchange/typing.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    # TypedDict is available in Python 3.8+
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+__all__ = [
+    'TypedDict',
+]

--- a/tests/open_exchange/test_rental_comps.py
+++ b/tests/open_exchange/test_rental_comps.py
@@ -1,3 +1,1 @@
-from __future__ import annotations
-
 # TODO: Investigate using https://github.com/stoplightio/prism for mocking


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Support Python 3.6

## Test Plan

```
asdf install python 3.6.15
rm -rf .venv
$(asdf where python 3.6.15)/bin/python -m venv .venv
poetry env use .venv/bin/python
poetry install
PYTHONPATH=src OPEN_EXCHANGE_API_KEY=$MY_KEY ./.venv/bin/python -m examples.rental_comps
```
